### PR TITLE
ultralight quarterly notes

### DIFF
--- a/roadmap/EF2023.md
+++ b/roadmap/EF2023.md
@@ -40,10 +40,9 @@ The [Ethers.js](https://github.com/ethers-io/ethers.js) library is one of the mo
 
 The following planning is based on the following theoretical assumptions on an outer timeline (note that there is no evidence or public statements that these dates will happen to any extend):
 
-
 - The Shanghai HF happening around Summer 2022 (including "base" EIPs, Withdrawals, no EOF)
 - A HF including EIP-4844 Shard Blob Transactions and a bundle of EOF EIPs later the year or early 2024
-- Verkle Tree integration *not* happening in 2023 yet
+- Verkle Tree integration _not_ happening in 2023 yet
 
 ---
 
@@ -142,6 +141,8 @@ The following planning is based on the following theoretical assumptions on an o
 - Post-Shanghai Functional EIP/HF Testnet
 - EthereumJS Client Portal Network Integration Feasibility Analysis
 - EthereumJS Client LES sync via engine API (Beacon Light Client)
+- Verkle Tree Specification updates
+- Verkle work towards syncing with consensus layer clients and testnets
 
 ### Portal Network
 
@@ -170,6 +171,8 @@ The following planning is based on the following theoretical assumptions on an o
 ### Research, Client & Testnets
 
 - EthereumJS Client Lightclient Strategy and Production Roadmap
+- Verkle work towards syncing with consensus layer clients and testnets
+- Verkle trie MVP implementation
 
 ### Portal Network
 
@@ -178,7 +181,6 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Ethers.js
 
-- This will be (likely) almost entirely focused on v7 features, refactoring and 
+- This will be (likely) almost entirely focused on v7 features, refactoring and
 - Migrating v6 ancillary packages to be v7-ready with collaborator assistance
 - Updating documentation for v7
-

--- a/roadmap/EF2024.md
+++ b/roadmap/EF2024.md
@@ -66,6 +66,11 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Ultralight (Portal Network) & Light Clients
 
+- Improve portal-network-specs based on feedback and analysis of early network use
+- Maintain Ultralight public bootnodes and bridge nodes
+- Update Ultralight code base with latest portal-network-specs changes
+- Develop solutions for browser and mobile client security and connection issues
+- Imlement merkle-trie research and draft prototype of Merkle based state client
 ### Ethers.js
 
 ---
@@ -84,6 +89,10 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Ultralight (Portal Network) & Light Clients
 
+  - Maintain Ultralight public bootnodes and bridge nodes
+  - Update and improve Ultralight UI
+  - Integrate mobile and browser solutions
+  - Test and improve Merkle-based state network specs and state client prototype
 ### Ethers.js
 
 ---
@@ -101,6 +110,11 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Ultralight (Portal Network) & Light Clients
 
+  - R&D towards portalnetwork support of Merkle->Verkle transition
+  - Maintain Ultralight public bootnodes and bridge nodes
+  - Observe, analyze, and debug early portal network behavior
+
+
 ### Ethers.js
 
 ---
@@ -116,5 +130,10 @@ The following planning is based on the following theoretical assumptions on an o
 - Participate in testnets and be "verkle-ready".
 
 ### Ultralight (Portal Network) & Light Clients
+
+- Implementation and testing of Verkle solutions in parallel with L1 testnets
+- Functional integration of portal clients with light clients
+- Maintain Ultralight public bootnodes and bridge nodes
+- Update ultralight client and networking stack with latest portal-network-specs changes
 
 ### Ethers.js

--- a/roadmap/EF2024.md
+++ b/roadmap/EF2024.md
@@ -26,7 +26,7 @@ The JavaScript team takes part in Ethereum protocol-related research and activel
 
 ### Verkle Roadmap Integration
 
-The research on verkle is nearing completion and it is expected that 2024 will be the year where parts of an integration/transition to a verkle tree based Ethereum network will happen. The JavaScript team is actively participating in the verkle testnet iteration runs like Condrieu or Kaustinen and we have started a TypeScript Verkle Trie implmenentation to make available to the TypeScript development community. 2024 will likely get a larger focus on the broader structural integration like Verkle based VM/client runs and implementations realizing the Merkle -> Verkle transition.
+The research on verkle is nearing completion and it is expected that 2024 will be the year where parts of an integration/transition to a verkle tree based Ethereum network will happen. The JavaScript team is actively participating in the verkle testnet iteration runs like Condrieu or Kaustinen and we have started a TypeScript Verkle Trie implementation to make available to the TypeScript development community. 2024 will likely get a larger focus on the broader structural integration like Verkle based VM/client runs and implementations realizing the Merkle -> Verkle transition.
 
 ### Ultralight (Portal Network) & Light Clients
 
@@ -56,20 +56,17 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Browser DevEx & Hardforks
 
-
-
 ### Applied Research & Testnet Support
-
 
 ### Verkle Roadmap Integration
 
-
+- Verkle trie functional implementation (with TypeScript-written cryptography)
+- Verkle Kaustinen testnet syncing
+- Expand StatelessStateManager (e.g. allow building state over time, handle incoming proofs)
 
 ### Ultralight (Portal Network) & Light Clients
 
-
 ### Ethers.js
-
 
 ---
 
@@ -77,17 +74,15 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Browser DevEx & Hardforks
 
-
-
 ### Applied Research & Testnet Support
-
 
 ### Verkle Roadmap Integration
 
-
+- Improve and expand verkle trie implementation
+- Early implementation of logic related to the Merkle->Verkle transition
+- Implement verkle-related cryptography (proof verification, proof creation and related helpers)
 
 ### Ultralight (Portal Network) & Light Clients
-
 
 ### Ethers.js
 
@@ -97,17 +92,14 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Browser DevEx & Hardforks
 
-
-
 ### Applied Research & Testnet Support
-
 
 ### Verkle Roadmap Integration
 
-
+- Full implementation of logic related to the Merkle->Verkle transition
+- Sync with future testnet iterations and participate in Merkle->Verkle transition testing
 
 ### Ultralight (Portal Network) & Light Clients
-
 
 ### Ethers.js
 
@@ -117,16 +109,12 @@ The following planning is based on the following theoretical assumptions on an o
 
 ### Browser DevEx & Hardforks
 
-
-
 ### Applied Research & Testnet Support
-
 
 ### Verkle Roadmap Integration
 
-
+- Participate in testnets and be "verkle-ready".
 
 ### Ultralight (Portal Network) & Light Clients
-
 
 ### Ethers.js

--- a/roadmap/EF2024.md
+++ b/roadmap/EF2024.md
@@ -30,11 +30,13 @@ The research on verkle is nearing completion and it is expected that 2024 will b
 
 ### Ultralight (Portal Network) & Light Clients
 
-With the [Ultralight](https://github.com/ethereumjs/ultralight) client and networking library stack the JavaScript team maintains one of the three leading client implementations for the Portal Network, a more lightweight but nevertheless sufficiently decentralized alternative to the Ethereum devp2p network.
+With the [Ultralight](https://github.com/ethereumjs/ultralight) client and networking library stack the JavaScript team maintains one of the three leading client implementations for the Portal Network, a protocol for a set of p2p networks that provide lightweight user access to protocol data and solutions for the challenges that L1 and L2 Ethereum clients face.  Ultralight implements a Node.js client serving the Portal-JSONRPC specs, as well a React-based client that runs in a Browser or on a Mobile device.  The Ultralight repository also includes an Browser based interface for exploring and interacting with locally running JSON-RPC clients of any kind.
 
-While the [Portal Network](https://github.com/ethereum/portal-network-specs) is still in the process of finding product-market-fit and experiments what kind of networks work better and which one not so well are ongoing, latest results using the Portal Network for serving beacon chain data are promising.
+Development of the [Portal Network](https://github.com/ethereum/portal-network-specs) is ongoing, with Javascript team members taking leading roles in the research and development of current and future Portal Network specifications.  Ultralight is one of three Portal Network client implementations involved in [Portal-Hive](http://github.com/ethereum/portal-hive) interoperability testing, with Javascript team members contributing to the Hive test suites as well.  
 
-We have tested an early-on prototype on this connecting the Lodestar consensus client to the Portal beacon network with Ultralight, which might lead to a new light client architecture for the beacon chain. We will continue and broaden experiments here as a focus for 2024. In parallel other Portal-based network applications are continued to evolved and tested regarding production feasibility.
+The PortalNetwork teams are currently overseeing the testing and deployment of the first networks.  2024 we will focus on observing the behavior and performance of these early networks and finding solutions issues that arise, as well as developing the Portal Network project towards full State access and other goals.  The Ultralight team will also continue to develop the Ultralight client and networking stack, while addressing the security and technical challenges of running a client in a browser environment as well as on mobile devices.
+
+We have tested an early-on prototype connecting the Lodestar consensus client to the Portal beacon network with Ultralight, which might lead to a new light client architecture for the beacon chain. We will continue and broaden experiments here as a focus for 2024. In parallel other Portal-based network applications are continued to evolved and tested regarding production feasibility.
 
 ### Ethers.js
 

--- a/roadmap/EF2024.md
+++ b/roadmap/EF2024.md
@@ -1,0 +1,130 @@
+# EF JavaScript Team Roadmap 2024
+
+This document reflects our initial planning for the respective year and represents
+the roadmap we have submitted internally within the EF.
+
+Things in the Ethereum ecosystem move quickly, so please note that we will likely deviate
+substantially from this initial roadmap throughout the year.
+
+See our "live" [roadmap](./README.md) document for an up-to-date overview on what we
+are currently up to.
+
+## Tracks
+
+The roadmap is divided into the following "tracks", identifying our main focus areas
+for the year.
+
+### Browser DevEx & Hardforks
+
+The [EthereumJS](https://github.com/ethereumjs/ethereumjs-monorepo) libraries are often used in a development context, serving e.g. as an integral part of main Ethereum developer tools or as building blocks for browser UIs of decentralized applications (dApps). Improving the experience when working with our libraries is therefore a crucial part of our work, with the VM playing a special role here due to the central place it takes in development tools like Hardhat, Truffle or Remix.
+
+This includes updating the JavaScript EVM to support the latest hardfork specification changes to provide respective early-on access for tools and in browser applications.
+
+### Applied Research & Testnet Support
+
+The JavaScript team takes part in Ethereum protocol-related research and actively supports developer testnets by providing early implementations of EIPs, contributing to and verfying the spec compliance of cross browser test cases (execution-specs and ethereum/tests suites). We use our EthereumJS [client implementation](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/client) as a research leveraging tool for early-on EIP testing in a multi-client context.
+
+### Verkle Roadmap Integration
+
+The research on verkle is nearing completion and it is expected that 2024 will be the year where parts of an integration/transition to a verkle tree based Ethereum network will happen. The JavaScript team is actively participating in the verkle testnet iteration runs like Condrieu or Kaustinen and we have started a TypeScript Verkle Trie implmenentation to make available to the TypeScript development community. 2024 will likely get a larger focus on the broader structural integration like Verkle based VM/client runs and implementations realizing the Merkle -> Verkle transition.
+
+### Ultralight (Portal Network) & Light Clients
+
+With the [Ultralight](https://github.com/ethereumjs/ultralight) client and networking library stack the JavaScript team maintains one of the three leading client implementations for the Portal Network, a more lightweight but nevertheless sufficiently decentralized alternative to the Ethereum devp2p network.
+
+While the [Portal Network](https://github.com/ethereum/portal-network-specs) is still in the process of finding product-market-fit and experiments what kind of networks work better and which one not so well are ongoing, latest results using the Portal Network for serving beacon chain data are promising.
+
+We have tested an early-on prototype on this connecting the Lodestar consensus client to the Portal beacon network with Ultralight, which might lead to a new light client architecture for the beacon chain. We will continue and broaden experiments here as a focus for 2024. In parallel other Portal-based network applications are continued to evolved and tested regarding production feasibility.
+
+### Ethers.js
+
+The [Ethers.js](https://github.com/ethers-io/ethers.js) library is one of the most popular tooling libraries used to and interact with the Ethereum network. Primarily maintained by [Richard Moore](https://github.com/ricmoo) the library is downloaded by far over 1 million users and developers each month. To further develop and maintain the library is therefore crucial to support the large community which has grown around the library over the years.
+
+---
+
+The following planning is based on the following theoretical assumptions on an outer timeline (note that there is no evidence or public statements that these dates will happen to any extend):
+
+- Dencun HF happening very early in 2024
+- Another more community-focused feature based HF happening sometime during 2024
+- First stages of Verkle (transition) preparation reaching HF deployment stage
+
+---
+
+## Q1
+
+### Browser DevEx & Hardforks
+
+
+
+### Applied Research & Testnet Support
+
+
+### Verkle Roadmap Integration
+
+
+
+### Ultralight (Portal Network) & Light Clients
+
+
+### Ethers.js
+
+
+---
+
+## Q2
+
+### Browser DevEx & Hardforks
+
+
+
+### Applied Research & Testnet Support
+
+
+### Verkle Roadmap Integration
+
+
+
+### Ultralight (Portal Network) & Light Clients
+
+
+### Ethers.js
+
+---
+
+## Q3
+
+### Browser DevEx & Hardforks
+
+
+
+### Applied Research & Testnet Support
+
+
+### Verkle Roadmap Integration
+
+
+
+### Ultralight (Portal Network) & Light Clients
+
+
+### Ethers.js
+
+---
+
+## Q4
+
+### Browser DevEx & Hardforks
+
+
+
+### Applied Research & Testnet Support
+
+
+### Verkle Roadmap Integration
+
+
+
+### Ultralight (Portal Network) & Light Clients
+
+
+### Ethers.js

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -29,6 +29,9 @@ list for an overview of the initial roadmaps from the respective years.
 ### Portal Network
 
 - Launch portalnetwork v1.0.0 with history/light client update/state network functionality
+- Improve Ultralight documentation and quickstart guide.
+- Maintain Ultralight public bootnodes and bridge nodes.
+- Update and improve Ultralight browser tools, demos, and documentation.
 - History Network Reference Production Integration Partnership (based on Q3 analysis)
 
 ### Ethers.js
@@ -56,8 +59,10 @@ list for an overview of the initial roadmaps from the respective years.
 
 ### Portal Network
 
-- Begin implementation of State Network prototype (or possible TX gossip)
-- Finish implementation of Rendezvous protocol in Discv5
+- [x] Deep testing and debugging of client interop in Portal-Hive
+- [x] Implement initial spec for Beacon Light Client Network
+- [x] Experimental integration of Portal and LightClient
+- [x] Convert Ultralight testing suite to vitest
 - History Network Reference Production Integration (e.g. EthOS, other) Analysis
 
 ### Ethers.js
@@ -94,7 +99,8 @@ list for an overview of the initial roadmaps from the respective years.
 ### Portal Network
 
 - Explore integration of Lodestar or Kevlar CL light client with Ultralight for feeding light client update data to Beacon Light Client Update Network
-- Build WebRTC transport layer for discv5 to allow direct p2p connections for browser clients
+- [x] Build WebRTC transport layer for discv5 to allow direct p2p connections for browser clients
+- [x] R&D of solutions to challenges in Merkle basic State Network design and client implementation
 - Begin implementation of Rendezvous protocol in Discv5
 
 ### Ethers.js
@@ -130,7 +136,7 @@ list for an overview of the initial roadmaps from the respective years.
 
 - Wrap up any loose ends from History Network implementation - (alpha version of portalnetwork module for chain history)
 - Implement prototype of Beacon light client update network
-- Begin exploration of WebRTC to allow for p2p discovery of browser clients using libp2p/waku gossip
+- [x] Begin exploration of WebRTC to allow for p2p discovery of browser clients using libp2p/waku gossip
 
 ### Ethers.js
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -10,8 +10,138 @@ list for an overview of the initial roadmaps from the respective years.
 - [2021](./EF2021.md)
 - [2022](./EF2022.md)
 - [2023](./EF2023.md)
+- [2024](./EF2024.md) [ DRAFT, October 13 2023 ]
 
-## Q4 2022 (incomplete)
+## Q4
+
+### DevEx & VM
+
+- [x] Breaking Monorepo Releases Community Support
+
+### Hardforks & EIPs
+
+- [x] Post-Shanghai EIP implementation Work
+
+### Research, Client & Testnets
+
+- [x] EthereumJS Client Lightclient Strategy and Production Roadmap (somewhat, lightclient paths more clear now, but still evolving)
+
+### Portal Network
+
+- Launch portalnetwork v1.0.0 with history/light client update/state network functionality
+- History Network Reference Production Integration Partnership (based on Q3 analysis)
+
+### Ethers.js
+
+- This will be (likely) almost entirely focused on v7 features, refactoring and 
+- Migrating v6 ancillary packages to be v7-ready with collaborator assistance
+- Updating documentation for v7
+
+## Q3
+
+### DevEx & VM
+
+- [x] Final Breaking Monorepo Releases
+
+### Hardforks & EIPs
+
+- [x] EIP-4844 Robustness Work & Live Testing
+- [x] ~~EOF EIPs Robustness Work & Live Testing~~ (EOF stuff postponed, roadmap changes)
+
+### Research, Client & Testnets
+
+- [x] ~~Post-Shanghai Functional EIP/HF Testnet~~ (no, turned out EIP-4844 taking a lot more space than expected)
+- [x] EthereumJS Client Portal Network Integration Feasibility Analysis (somewhat: Lodestar/Ultralight integration)
+- [x] EthereumJS Client LES sync via engine API (Beacon Light Client) (somewhat: Lodestar/Ultralight integration -> CLient integration with Lodestar/Ultralight)
+
+### Portal Network
+
+- Begin implementation of State Network prototype (or possible TX gossip)
+- Finish implementation of Rendezvous protocol in Discv5
+- History Network Reference Production Integration (e.g. EthOS, other) Analysis
+
+### Ethers.js
+
+- Ancillary libraries for Contract Wallets; a small (but vocal) group has been advocating for this, so it may be moved earlier; the goal is to get a working demo and then allow them to further contribute
+- More serious planning for v7, as I want to switch to a more regular annual release cycle to reduce the impact on version bumps by making more, smaller major releases
+- Expand the cookbook section with more real-world examples, with JS and Solidity; EIP-712, signing, tokens, etc.
+
+## Q2
+
+### DevEx & VM
+
+- [x] ~~VM/EVM Optimism L2 Support Integration (depends on Q1 analysis)~~ postponed, but some base work done in PR [#2713](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2713)
+- [x] Monorepo-wide Node.js Buffer -> Uint8Array Switch (huge, but: Browser + React Compatibility!) 🎉
+- [x] Transaction Library Refactor (Modularize -> Typed Tx Diversification!) (later: Q3 2023)
+- [x] Monorepo-wide ESM Build Support (along Summer 2023 breaking releases)
+- [x] Breaking Monorepo Releases v7 (Beta)
+
+### Hardforks & EIPs
+
+- [x] EIP-4844 Shard Blob Transactions Spec Finalization (later, spec not finalized at that point)
+- [x] ~~EOF Implementation: EIP-4200 Static Relative Jumps~~ (EOF stuff postponed, roadmap changes)
+- [x] ~~EOF Implementation: EIP-4750 EOF Functions~~ (EOF stuff postponed, roadmap changes)
+- [x] Shanghai HF Preparations (Testnets, Developer Tools, Community Support)
+
+### Research, Client & Testnets
+
+- [x] EIP-4844 Shard Blob Transactions Multi-Client Testnet
+- [x] ~~Multi-client EOF-focused testnet~~ (EOF stuff postponed, roadmap changes)
+- [x] Verkle Tree Specification Updates
+- [x] ~~EthereumJS Client SNAP Sync Production Release~~ (no, takes longer than expected)
+- [x] Client In-browser sync feasibility analysis (Lodestar Light Client + Sepolia LES)
+
+### Portal Network
+
+- Explore integration of Lodestar or Kevlar CL light client with Ultralight for feeding light client update data to Beacon Light Client Update Network
+- Build WebRTC transport layer for discv5 to allow direct p2p connections for browser clients
+- Begin implementation of Rendezvous protocol in Discv5
+
+### Ethers.js
+
+- Release tools.ethers.org, a tool to simplify many common debugging tasks as well as quickly testing open issues marked “investigate” (currently playground.ethers.org handles much of this, but tools is for more specific issues)
+- Begin opening up additional repositories, adding other external contributors to help with Network-specific v6 plugins and ancillary libraries like LedgerSigner
+- Migrate many “common” issues/discussions to the documentation cookbook section and Ethereum basics section and add links to the issues/discussions to these sections of the documentation
+
+## Q1
+
+### DevEx & VM
+
+- [x] VM/EVM Performance Improvements (Memory Management, Others)
+- [x] VM/EVM (Other) Post-Breaking Release API Optimizations
+- [x] VM/EVM Optimism L2 Support Feasibility Analysis (partly, see PR [#2713](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2713) and related)
+- [x] EVM Standalong Capabilities (after VM/EVM extraction) (done a bit later along Summer 2023 breaking releases)
+
+### Hardforks & EIPs
+
+- [x] EIP-4844 Shard Blob Transactions Draft & Local Geth Testnet Integration
+- [x] EIP-4844 Shard Blob Transactions KZG Library Analysis & Integration
+- [x] EIP-4895 Beacon Chain Withdrawals (Shanghai) Spec Finalization
+
+### Research, Client & Testnets
+
+- [x] Integration of the EthereumJS Client with Verkle Testnets (Condrieu, Beverly Hills, and Future Ones)
+- [x] Verkle Trie "Stateless" State Management and Proof Verification
+- [x] Verkle Tree Specification Work & Performance Analysis
+- [x] EthereumJS Client SNAP Sync Draft Implementation (yes, but later)
+- [x] ~Reactivate Client Browser Build~ -> Stalled until active use case (statelessness)
+
+### Portal Network
+
+- Wrap up any loose ends from History Network implementation - (alpha version of portalnetwork module for chain history)
+- Implement prototype of Beacon light client update network
+- Begin exploration of WebRTC to allow for p2p discovery of browser clients using libp2p/waku gossip
+
+### Ethers.js
+
+- Documentation-specific pull request templates, GitHub actions and webforms to streamline (while retaining safety) user-contributed documentation changes to code
+- Much richer stats and tools to drill down into build.ethers.org for tracking changes, code coverage and testing (especially for auditing purposes)
+- More documentation, especially regarding Ethereum basics, based on common issues; this will be open to additional contributors too
+- Aggressive resolving and closing of GitHub issues and PRs; hopefully v6 will have resolved many of these, others can be migrated to discussions
+- Migrating to (or at least making a stronger presence) Mastodon for ethers for its advisories
+
+
+## Q4 2022
 
 ### DevEx & VM
 


### PR DESCRIPTION
This adds a propsective 2024 quarterly roadmap for the Ultralight team.

Also fills in 2023 quareterly report for Ultralight Team